### PR TITLE
add unit tests

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,11 @@ var rootCmd = &cobra.Command{
 	Long:  `Kurohabaki is a lightweight WireGuard-based P2P networking client.`,
 }
 
+func init() {
+	// vewrsion flag
+	rootCmd.Version = "0.1.0"
+}
+
 // Execute runs the root command
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestRootCommand(t *testing.T) {
+	// Backup the original rootCmd
+	originalRootCmd := rootCmd
+	defer func() { rootCmd = originalRootCmd }()
+
+	t.Run("RootCommandBasicExecution", func(t *testing.T) {
+		// Create a buffer to capture command output
+		buf := new(bytes.Buffer)
+		rootCmd.SetOut(buf)
+		rootCmd.SetErr(buf)
+
+		// Execute help command
+		rootCmd.SetArgs([]string{"--help"})
+		err := rootCmd.Execute()
+
+		// Verify no error occurred
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		// Verify output contains the title
+		output := buf.String()
+		if !bytes.Contains(buf.Bytes(), []byte("Kurohabaki")) {
+			t.Errorf("Expected output to contain 'Kurohabaki', got: %s", output)
+		}
+	})
+
+	t.Run("RootCommandVersion", func(t *testing.T) {
+		// Create a buffer to capture command output
+		buf := new(bytes.Buffer)
+		rootCmd.SetOut(buf)
+		rootCmd.SetErr(buf)
+
+		// Verify version information is displayed
+		rootCmd.SetArgs([]string{"--version"})
+		err := rootCmd.Execute()
+
+		// Verify no error occurred
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("RootCommandErrorHandling", func(t *testing.T) {
+		// Add a subcommand that returns an error
+		errCmd := &cobra.Command{
+			Use: "error-test",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return fmt.Errorf("test error")
+			},
+		}
+
+		// Create a new rootCmd for testing
+		testRootCmd := &cobra.Command{
+			Use:   "kurohabaki",
+			Short: "Kurohabaki client CLI",
+			Long:  `Kurohabaki is a lightweight WireGuard-based P2P networking client.`,
+		}
+		testRootCmd.AddCommand(errCmd)
+		rootCmd = testRootCmd
+
+		// Execute the command that returns an error and test error handling
+		testRootCmd.SetArgs([]string{"error-test"})
+		err := testRootCmd.Execute()
+
+		if err == nil {
+			t.Error("Expected error but got nil")
+		}
+
+		if err.Error() != "test error" {
+			t.Errorf("Expected 'test error', got '%v'", err)
+		}
+	})
+}
+
+func TestExecute(t *testing.T) {
+	// Direct testing of Execute() is difficult as it calls os.Exit
+	// Here we just verify the function exists
+	// Actual testing is covered indirectly by testing rootCmd behavior
+
+	// Another approach would be to temporarily mock rootCmd.Execute
+	// to prevent it from exiting, but that may be excessive for this simple case
+}

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestUpCommandStructure(t *testing.T) {
+	// Test the basic structure of upCmd
+	if upCmd.Use != "up" {
+		t.Errorf("Expected Use to be 'up', got '%s'", upCmd.Use)
+	}
+
+	if upCmd.Short == "" {
+		t.Error("Expected Short description to be set")
+	}
+
+	// Verify that RunE function is set
+	if upCmd.RunE == nil {
+		t.Error("Expected RunE function to be set")
+	}
+}
+
+func TestUpCommandRegistration(t *testing.T) {
+	// Test that upCmd is registered to rootCmd
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Use == "up" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("up command not registered to rootCmd")
+	}
+}
+
+// This is a simple test that avoids complex dependencies
+// Actual functionality tests are omitted for now

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,120 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoad(t *testing.T) {
+	// Create a temporary test directory
+	tempDir, err := os.MkdirTemp("", "kurohabaki-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	t.Run("ValidConfig", func(t *testing.T) {
+		// Create a valid test config file
+		configPath := filepath.Join(tempDir, "valid-config.yaml")
+		configData := `
+interface:
+  private_key: ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghi=
+  address: 10.0.0.2/24
+  dns: 1.1.1.1
+  routes:
+    - 0.0.0.0/0
+peer:
+  public_key: ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghi=
+  endpoint: 192.168.1.1:51820
+  allowed_ips: 0.0.0.0/0
+  persistent_keepalive: 25
+etcd:
+  endpoint: 192.168.1.100:2379
+`
+		if err := os.WriteFile(configPath, []byte(configData), 0644); err != nil {
+			t.Fatalf("Failed to write test config file: %v", err)
+		}
+
+		// Load the config
+		cfg, err := Load(configPath)
+		if err != nil {
+			t.Fatalf("Failed to load valid config: %v", err)
+		}
+
+		// Verify config values
+		if cfg.Interface.PrivateKey != "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghi=" {
+			t.Errorf("Expected PrivateKey to be ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghi=, got %s", cfg.Interface.PrivateKey)
+		}
+		if cfg.Interface.Address != "10.0.0.2/24" {
+			t.Errorf("Expected Address to be 10.0.0.2/24, got %s", cfg.Interface.Address)
+		}
+		if cfg.Interface.DNS != "1.1.1.1" {
+			t.Errorf("Expected DNS to be 1.1.1.1, got %s", cfg.Interface.DNS)
+		}
+		if len(cfg.Interface.Routes) != 1 || cfg.Interface.Routes[0] != "0.0.0.0/0" {
+			t.Errorf("Expected Routes to contain [0.0.0.0/0], got %v", cfg.Interface.Routes)
+		}
+		if cfg.ServerConfig.PublicKey != "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghi=" {
+			t.Errorf("Expected PublicKey to be ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghi=, got %s", cfg.ServerConfig.PublicKey)
+		}
+		if cfg.ServerConfig.Endpoint != "192.168.1.1:51820" {
+			t.Errorf("Expected Endpoint to be 192.168.1.1:51820, got %s", cfg.ServerConfig.Endpoint)
+		}
+		if cfg.ServerConfig.AllowedIPs != "0.0.0.0/0" {
+			t.Errorf("Expected AllowedIPs to be 0.0.0.0/0, got %s", cfg.ServerConfig.AllowedIPs)
+		}
+		if cfg.ServerConfig.PersistentKeepalive != 25 {
+			t.Errorf("Expected PersistentKeepalive to be 25, got %d", cfg.ServerConfig.PersistentKeepalive)
+		}
+		if cfg.Etcd.Endpoint != "192.168.1.100:2379" {
+			t.Errorf("Expected Etcd endpoint to be 192.168.1.100:2379, got %s", cfg.Etcd.Endpoint)
+		}
+	})
+
+	t.Run("FileNotExist", func(t *testing.T) {
+		nonExistentPath := filepath.Join(tempDir, "non-existent.yaml")
+		_, err := Load(nonExistentPath)
+		if err == nil {
+			t.Error("Expected error when loading non-existent file, got nil")
+		}
+	})
+
+	t.Run("InvalidYAML", func(t *testing.T) {
+		// Create an invalid YAML file
+		invalidPath := filepath.Join(tempDir, "invalid.yaml")
+		invalidData := `
+interface:
+  private_key: ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghi=
+  address: 10.0.0.2/24
+  This is not valid YAML!
+  dns: 1.1.1.1
+`
+		if err := os.WriteFile(invalidPath, []byte(invalidData), 0644); err != nil {
+			t.Fatalf("Failed to write invalid config file: %v", err)
+		}
+
+		_, err := Load(invalidPath)
+		if err == nil {
+			t.Error("Expected error when loading invalid YAML, got nil")
+		}
+	})
+
+	t.Run("EmptyFile", func(t *testing.T) {
+		// Create an empty file
+		emptyPath := filepath.Join(tempDir, "empty.yaml")
+		if err := os.WriteFile(emptyPath, []byte{}, 0644); err != nil {
+			t.Fatalf("Failed to write empty file: %v", err)
+		}
+
+		cfg, err := Load(emptyPath)
+		if err != nil {
+			t.Fatalf("Failed to load empty file: %v", err)
+		}
+
+		// Empty YAML is valid but should result in zero values
+		if cfg.Interface.PrivateKey != "" {
+			t.Errorf("Expected empty PrivateKey, got %s", cfg.Interface.PrivateKey)
+		}
+	})
+}

--- a/internal/wg/configbuilder_test.go
+++ b/internal/wg/configbuilder_test.go
@@ -1,0 +1,168 @@
+package wg
+
+import (
+	"net"
+	"testing"
+
+	"golang.zx2c4.com/wireguard/device"
+)
+
+func TestSamePeers(t *testing.T) {
+	// Helper function to create a test public key
+	createPubKey := func(byte byte) device.NoisePublicKey {
+		var key device.NoisePublicKey
+		for i := range key {
+			key[i] = byte
+		}
+		return key
+	}
+
+	// Helper function to create a test UDP address
+	createUDPAddr := func(ip string, port int) *net.UDPAddr {
+		return &net.UDPAddr{
+			IP:   net.ParseIP(ip),
+			Port: port,
+		}
+	}
+
+	// Helper function to create test allowed IPs
+	createAllowedIP := func(cidr string) net.IPNet {
+		_, ipnet, _ := net.ParseCIDR(cidr)
+		return *ipnet
+	}
+
+	// Helper function to create a uint16 pointer
+	uint16Ptr := func(v int) *uint16 {
+		u := uint16(v)
+		return &u
+	}
+
+	tests := []struct {
+		name     string
+		peersA   []WGPeerConfig
+		peersB   []WGPeerConfig
+		expected bool
+	}{
+		{
+			name:     "Empty lists",
+			peersA:   []WGPeerConfig{},
+			peersB:   []WGPeerConfig{},
+			expected: true,
+		},
+		{
+			name: "Same single peer",
+			peersA: []WGPeerConfig{
+				{
+					PublicKey:                   createPubKey(1),
+					Endpoint:                    createUDPAddr("192.168.1.1", 51820),
+					PersistentKeepaliveInterval: uint16Ptr(25),
+					ReplaceAllowedIPs:           true,
+					AllowedIPs:                  []net.IPNet{createAllowedIP("10.0.0.1/32")},
+				},
+			},
+			peersB: []WGPeerConfig{
+				{
+					PublicKey:                   createPubKey(1),
+					Endpoint:                    createUDPAddr("192.168.1.1", 51820),
+					PersistentKeepaliveInterval: uint16Ptr(25),
+					ReplaceAllowedIPs:           true,
+					AllowedIPs:                  []net.IPNet{createAllowedIP("10.0.0.1/32")},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Different public keys",
+			peersA: []WGPeerConfig{
+				{
+					PublicKey: createPubKey(1),
+					Endpoint:  createUDPAddr("192.168.1.1", 51820),
+				},
+			},
+			peersB: []WGPeerConfig{
+				{
+					PublicKey: createPubKey(2),
+					Endpoint:  createUDPAddr("192.168.1.1", 51820),
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Different endpoints",
+			peersA: []WGPeerConfig{
+				{
+					PublicKey: createPubKey(1),
+					Endpoint:  createUDPAddr("192.168.1.1", 51820),
+				},
+			},
+			peersB: []WGPeerConfig{
+				{
+					PublicKey: createPubKey(1),
+					Endpoint:  createUDPAddr("192.168.1.2", 51820),
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Different lengths",
+			peersA: []WGPeerConfig{
+				{
+					PublicKey: createPubKey(1),
+					Endpoint:  createUDPAddr("192.168.1.1", 51820),
+				},
+			},
+			peersB: []WGPeerConfig{
+				{
+					PublicKey: createPubKey(1),
+					Endpoint:  createUDPAddr("192.168.1.1", 51820),
+				},
+				{
+					PublicKey: createPubKey(2),
+					Endpoint:  createUDPAddr("192.168.1.2", 51820),
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Nil endpoint in one peer",
+			peersA: []WGPeerConfig{
+				{
+					PublicKey: createPubKey(1),
+					Endpoint:  nil,
+				},
+			},
+			peersB: []WGPeerConfig{
+				{
+					PublicKey: createPubKey(1),
+					Endpoint:  createUDPAddr("192.168.1.1", 51820),
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Both nil endpoints",
+			peersA: []WGPeerConfig{
+				{
+					PublicKey: createPubKey(1),
+					Endpoint:  nil,
+				},
+			},
+			peersB: []WGPeerConfig{
+				{
+					PublicKey: createPubKey(1),
+					Endpoint:  nil,
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SamePeers(tt.peersA, tt.peersB)
+			if result != tt.expected {
+				t.Errorf("SamePeers() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
```
go test ./... -cover
        github.com/pabotesu/kurohabaki-client           coverage: 0.0% of statements
ok      github.com/pabotesu/kurohabaki-client/cmd       0.448s  coverage: 6.1% of statements
ok      github.com/pabotesu/kurohabaki-client/config    0.242s  coverage: 100.0% of statements
        github.com/pabotesu/kurohabaki-client/internal/agent            coverage: 0.0% of statements
        github.com/pabotesu/kurohabaki-client/internal/etcd             coverage: 0.0% of statements
ok      github.com/pabotesu/kurohabaki-client/internal/wg       0.651s  coverage: 10.5% of statements

kurohabaki_client on  test [!?] via  v1.24.3 via  impure (nix-shell-env) 
```