### PR TITLE
debugモードの追加

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -79,6 +79,13 @@ var upCmd = &cobra.Command{
 		}
 		defer etcdCli.Close()
 
+		// Check etcd health
+		if err := etcd.CheckEtcdHealth(etcdCli); err != nil {
+			logger.Println("⚠️ Warning: " + err.Error())
+			logger.Println("⚠️ Will continue but peer synchronization may not work")
+			// Don't return error here, allow to continue with local config
+		}
+
 		privKey, err := wgtypes.ParseKey(cfg.Interface.PrivateKey)
 		if err != nil {
 			return fmt.Errorf("failed to parse private key: %w", err)

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -112,6 +112,9 @@ var upCmd = &cobra.Command{
 		// Handle signals for graceful shutdown
 		go func() {
 			sig := <-sigCh
+			// Log the signal caught
+			logger.Printf("Received signal: %v, shutting down agent...", sig)
+			// Log the signal caught
 			logger.Printf("🛑 Caught signal: %v, shutting down...", sig)
 			cancel()
 		}()

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -11,10 +11,12 @@ import (
 
 	"github.com/pabotesu/kurohabaki-client/config"
 	"github.com/pabotesu/kurohabaki-client/internal/agent"
+	"github.com/pabotesu/kurohabaki-client/internal/etcd"
 	"github.com/pabotesu/kurohabaki-client/internal/logger"
 	"github.com/pabotesu/kurohabaki-client/internal/wg"
 	"github.com/spf13/cobra"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
@@ -60,9 +62,17 @@ var upCmd = &cobra.Command{
 		logger.Println("WireGuard interface is up")
 		// Prevent process from exiting to keep interface alive
 
+		// Configure etcd logging based on debug mode
+		etcd.ConfigureEtcdLogger(debugMode)
+
+		// Get the logger
+		zapLogger := zap.L()
+
+		// Initialize etcd client with custom logger
 		etcdCli, err := clientv3.New(clientv3.Config{
 			Endpoints:   []string{cfg.Etcd.Endpoint},
 			DialTimeout: 5 * time.Second,
+			Logger:      zapLogger, // Add this line
 		})
 		if err != nil {
 			return fmt.Errorf("failed to connect to etcd: %w", err)

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -81,8 +81,9 @@ var upCmd = &cobra.Command{
 
 		// Check etcd health
 		if err := etcd.CheckEtcdHealth(etcdCli); err != nil {
+			// 改行を避け、一貫した形式でログを出力
 			logger.Println("⚠️ Warning: " + err.Error())
-			logger.Println("⚠️ Will continue but peer synchronization may not work")
+			logger.Println("⚠️ Will continue with local configuration but peer discovery may not work")
 			// Don't return error here, allow to continue with local config
 		}
 

--- a/internal/agent/peerwatcher.go
+++ b/internal/agent/peerwatcher.go
@@ -11,7 +11,7 @@ import (
 )
 
 func StartPeerWatcher(ctx context.Context, cli *clientv3.Client, wgIf *wg.WireGuardInterface, selfPubKey string) {
-	logger.Println("🟡 StartPeerWatcher: launched")
+	logger.Println("StartPeerWatcher: launched") // デバッグモードでのみ表示
 
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
@@ -21,41 +21,51 @@ func StartPeerWatcher(ctx context.Context, cli *clientv3.Client, wgIf *wg.WireGu
 	for {
 		select {
 		case <-ctx.Done():
-			logger.Println("🔴 Peer watcher shutting down...")
+			// シャットダウン時のログはデバッグモードでのみ表示
+			logger.Println("Peer watcher shutting down...")
 			return
 
 		case <-ticker.C:
-			logger.Println("🔵 FetchPeers: start fetching from etcd...")
+			// 定期的なフェッチ開始のログはデバッグモードでのみ表示
+			logger.Println("FetchPeers: start fetching from etcd...")
+
 			peers, err := etcd.FetchPeers(cli, selfPubKey)
 			if err != nil {
-				// Clean, user-friendly error without technical details
-				logger.Println("❌ Failed to fetch peers: " + err.Error())
+				// エラーは常に表示（重要な問題なので）
+				logger.Printf("Failed to fetch peers: %s", err.Error())
 				continue
 			}
 
-			logger.Printf("🟢 FetchPeers: %d node(s) fetched", len(peers))
-			for _, n := range peers {
-				logger.Printf("🧩 Node: %+v", n)
+			// 以下のログはデバッグモードでのみ表示
+			logger.Printf("FetchPeers: %d node(s) fetched", len(peers))
+			if logger.IsDebugMode() {
+				for _, n := range peers {
+					logger.Printf("Node details: %+v", n)
+				}
 			}
 
 			currentPeers, err := wg.ConvertNodesToPeers(peers)
 			if err != nil {
-				logger.Printf("❌ Failed to convert nodes to peers: %v", err)
+				// 変換エラーは重要なので常に表示
+				logger.Printf("Failed to convert nodes to peers: %v", err)
 				continue
 			}
 
-			logger.Printf("📶 Peers converted: %d", len(currentPeers))
+			// デバッグ情報
+			logger.Printf("Peers converted: %d", len(currentPeers))
 
 			if !wg.SamePeers(prevPeers, currentPeers) {
-				logger.Println("⚠️ Peer list updated, applying to interface...")
+				// ピア変更は重要なので非デバッグモードでも表示
+				logger.Println("Peer list updated, applying to interface...")
 				if err := wgIf.UpdatePeers(currentPeers); err != nil {
-					logger.Printf("❌ Failed to update WireGuard peers: %v", err)
+					logger.Printf("Failed to update WireGuard peers: %v", err)
 				} else {
 					prevPeers = currentPeers
-					logger.Println("✅ Peers updated successfully")
+					logger.Println("Peers updated successfully")
 				}
 			} else {
-				logger.Println("✔️ No peer changes detected")
+				// 変更なしはデバッグモードでのみ表示
+				logger.Println("No peer changes detected")
 			}
 		}
 	}

--- a/internal/agent/peerwatcher.go
+++ b/internal/agent/peerwatcher.go
@@ -2,16 +2,16 @@ package agent
 
 import (
 	"context"
-	"log"
 	"time"
 
 	"github.com/pabotesu/kurohabaki-client/internal/etcd"
+	"github.com/pabotesu/kurohabaki-client/internal/logger"
 	"github.com/pabotesu/kurohabaki-client/internal/wg"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 func StartPeerWatcher(ctx context.Context, cli *clientv3.Client, wgIf *wg.WireGuardInterface, selfPubKey string) {
-	log.Println("🟡 StartPeerWatcher: launched")
+	logger.Println("🟡 StartPeerWatcher: launched")
 
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
@@ -21,40 +21,41 @@ func StartPeerWatcher(ctx context.Context, cli *clientv3.Client, wgIf *wg.WireGu
 	for {
 		select {
 		case <-ctx.Done():
-			log.Println("🔴 Peer watcher shutting down...")
+			logger.Println("🔴 Peer watcher shutting down...")
 			return
 
 		case <-ticker.C:
-			log.Println("🔵 FetchPeers: start fetching from etcd...")
+			logger.Println("🔵 FetchPeers: start fetching from etcd...")
 			nodes, err := etcd.FetchPeers(cli, selfPubKey)
 			if err != nil {
-				log.Printf("❌ Failed to fetch peers from etcd: %v", err)
+				// More user-friendly error message without stack trace
+				logger.Printf("❌ %v", err)
 				continue
 			}
 
-			log.Printf("🟢 FetchPeers: %d node(s) fetched", len(nodes))
+			logger.Printf("🟢 FetchPeers: %d node(s) fetched", len(nodes))
 			for _, n := range nodes {
-				log.Printf("🧩 Node: %+v", n)
+				logger.Printf("🧩 Node: %+v", n)
 			}
 
 			currentPeers, err := wg.ConvertNodesToPeers(nodes)
 			if err != nil {
-				log.Printf("❌ Failed to convert nodes to peers: %v", err)
+				logger.Printf("❌ Failed to convert nodes to peers: %v", err)
 				continue
 			}
 
-			log.Printf("📶 Peers converted: %d", len(currentPeers))
+			logger.Printf("📶 Peers converted: %d", len(currentPeers))
 
 			if !wg.SamePeers(prevPeers, currentPeers) {
-				log.Println("⚠️ Peer list updated, applying to interface...")
+				logger.Println("⚠️ Peer list updated, applying to interface...")
 				if err := wgIf.UpdatePeers(currentPeers); err != nil {
-					log.Printf("❌ Failed to update WireGuard peers: %v", err)
+					logger.Printf("❌ Failed to update WireGuard peers: %v", err)
 				} else {
 					prevPeers = currentPeers
-					log.Println("✅ Peers updated successfully")
+					logger.Println("✅ Peers updated successfully")
 				}
 			} else {
-				log.Println("✔️ No peer changes detected")
+				logger.Println("✔️ No peer changes detected")
 			}
 		}
 	}

--- a/internal/agent/peerwatcher.go
+++ b/internal/agent/peerwatcher.go
@@ -26,19 +26,19 @@ func StartPeerWatcher(ctx context.Context, cli *clientv3.Client, wgIf *wg.WireGu
 
 		case <-ticker.C:
 			logger.Println("🔵 FetchPeers: start fetching from etcd...")
-			nodes, err := etcd.FetchPeers(cli, selfPubKey)
+			peers, err := etcd.FetchPeers(cli, selfPubKey)
 			if err != nil {
-				// More user-friendly error message without stack trace
-				logger.Printf("❌ %v", err)
+				// Clean, user-friendly error without technical details
+				logger.Println("❌ Failed to fetch peers: " + err.Error())
 				continue
 			}
 
-			logger.Printf("🟢 FetchPeers: %d node(s) fetched", len(nodes))
-			for _, n := range nodes {
+			logger.Printf("🟢 FetchPeers: %d node(s) fetched", len(peers))
+			for _, n := range peers {
 				logger.Printf("🧩 Node: %+v", n)
 			}
 
-			currentPeers, err := wg.ConvertNodesToPeers(nodes)
+			currentPeers, err := wg.ConvertNodesToPeers(peers)
 			if err != nil {
 				logger.Printf("❌ Failed to convert nodes to peers: %v", err)
 				continue

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -43,3 +43,8 @@ func Printf(format string, v ...interface{}) {
 	}
 	stdLog.Printf(format, v...)
 }
+
+// IsDebugMode returns the current debug mode status
+func IsDebugMode() bool {
+	return debugMode
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,45 @@
+package logger
+
+import (
+	"io"
+	"log"
+	"os"
+)
+
+var (
+	// Debug mode status
+	debugMode bool
+	// Standard logger
+	stdLog *log.Logger
+)
+
+// Init initializes the logger
+func Init(debug bool) {
+	debugMode = debug
+
+	// Configure output destination
+	var output io.Writer
+	if debugMode {
+		output = os.Stdout
+	} else {
+		output = io.Discard // No output when not in debug mode
+	}
+
+	stdLog = log.New(output, "", log.LstdFlags)
+}
+
+// Println outputs log messages only in debug mode
+func Println(v ...interface{}) {
+	if stdLog == nil {
+		Init(false)
+	}
+	stdLog.Println(v...)
+}
+
+// Printf outputs formatted log messages only in debug mode
+func Printf(format string, v ...interface{}) {
+	if stdLog == nil {
+		Init(false)
+	}
+	stdLog.Printf(format, v...)
+}

--- a/internal/wg/interface.go
+++ b/internal/wg/interface.go
@@ -20,22 +20,27 @@ type WireGuardInterface struct {
 }
 
 // NewWireGuardInterface creates and initializes a new WireGuard TUN interface (Linux only)
-func NewWireGuardInterface(name string) (*WireGuardInterface, error) {
-	tunDev, err := tun.CreateTUN(name, device.DefaultMTU)
+func NewWireGuardInterface(ifname string) (*WireGuardInterface, error) {
+	// Create the TUN device
+	tunDev, err := tun.CreateTUN(ifname, device.DefaultMTU)
 	if err != nil {
-		log.Fatalf("failed to create TUN device: %v", err)
+		return nil, fmt.Errorf("failed to create TUN device: %w", err)
 	}
-	log.Printf("Created TUN device: %s\n", name)
 
-	bind := conn.NewDefaultBind()
+	// Log device creation in debug mode
+	log.Println("Created TUN device:", ifname)
 
-	logger := device.NewLogger(device.LogLevelVerbose, fmt.Sprintf("[WG-%s] ", name))
+	// Set logging for WireGuard device based on debug mode
+	// Set log level to error by default; change to LogLevelVerbose for more detailed logs if needed.
+	logLevel := device.LogLevelError // only log errors by default
 
-	wgDev := device.NewDevice(tunDev, bind, logger)
+	// Uncomment the following line for verbose logging during development:
+	// Create WireGuard device with appropriate log level
+	dev := device.NewDevice(tunDev, conn.NewDefaultBind(), device.NewLogger(logLevel, fmt.Sprintf("[WG-%s] ", ifname)))
 
 	return &WireGuardInterface{
-		ifName: name,
-		dev:    wgDev,
+		ifName: ifname,
+		dev:    dev,
 	}, nil
 }
 

--- a/internal/wg/interface.go
+++ b/internal/wg/interface.go
@@ -34,7 +34,8 @@ func NewWireGuardInterface(ifname string) (*WireGuardInterface, error) {
 	// Set log level to error by default; change to LogLevelVerbose for more detailed logs if needed.
 	logLevel := device.LogLevelError // only log errors by default
 
-	// デバッグモードが有効な場合はより詳細なログを表示
+	// If debug mode is enabled, set log level to verbose
+	// This allows for more detailed logging during development or troubleshooting.
 	if logger.IsDebugMode() {
 		logLevel = device.LogLevelVerbose
 	}
@@ -106,10 +107,8 @@ func (w *WireGuardInterface) Up(cfg *WGConfig) error {
 			}
 		}
 	}
-
-	// インターフェース起動のログ
+	// Bring the interface up
 	logger.Println("WireGuard interface is up")
-
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -1,12 +1,11 @@
 package main
 
 import (
-	"log"
-
 	"github.com/pabotesu/kurohabaki-client/cmd"
+	"github.com/pabotesu/kurohabaki-client/internal/logger"
 )
 
 func main() {
-	log.Println("kurohabaki client starting...")
+	logger.Println("kurohabaki client starting...")
 	cmd.Execute()
 }


### PR DESCRIPTION
### 概要
クライアントアプリの`up`サブコマンドに`--debug`モードを追加する
基本的に設計として、upコマンド時に各エージェントたちが起動するので、現在、`--debug`が必要なのは`up`コマンドのみ

### 利用イメージ
```
 sudo ./kurohabaki up --config ./config.yaml --debug
```