### PR TITLE
downコマンドを実装する

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/pabotesu/kurohabaki-client/internal/logger"
+	"github.com/pabotesu/kurohabaki-client/internal/util"
 	"github.com/spf13/cobra"
 )
 
@@ -14,29 +16,44 @@ var downCmd = &cobra.Command{
 	Use:   "down",
 	Short: "Stop the running WireGuard interface and agent",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Get the appropriate PID file path based on OS and permissions
+		pidFile := util.GetPidFilePath()
+
 		// Check if PID file exists
-		pidFile := "/var/run/kh-client.pid"
-		pidData, err := os.ReadFile(pidFile)
-		if err != nil {
-			return fmt.Errorf("no running agent found: %w", err)
+		if _, err := os.Stat(pidFile); os.IsNotExist(err) {
+			return fmt.Errorf("no running agent found: PID file does not exist")
 		}
 
-		// Parse PID
-		pid, err := strconv.Atoi(string(pidData))
+		// Read PID file
+		pidData, err := os.ReadFile(pidFile)
 		if err != nil {
-			return fmt.Errorf("invalid PID in pidfile: %w", err)
+			return fmt.Errorf("failed to read PID file: %w", err)
+		}
+
+		// Parse PID - trim any whitespace
+		pidStr := strings.TrimSpace(string(pidData))
+		pid, err := strconv.Atoi(pidStr)
+		if err != nil {
+			// Remove invalid PID file
+			os.Remove(pidFile)
+			return fmt.Errorf("invalid PID in pidfile (file removed): %w", err)
 		}
 
 		// Find the process
 		process, err := os.FindProcess(pid)
 		if err != nil {
-			return fmt.Errorf("failed to find process with PID %d: %w", pid, err)
+			// Remove PID file if process not found
+			os.Remove(pidFile)
+			return fmt.Errorf("failed to find process with PID %d (file removed): %w", pid, err)
 		}
 
 		// Send SIGTERM to gracefully shut down the agent
-		logger.Println("Sending shutdown signal to agent (PID: " + strconv.Itoa(pid) + ")...")
+		logger.Printf("Sending shutdown signal to agent (PID: %d)...", pid)
 		if err := process.Signal(syscall.SIGTERM); err != nil {
-			return fmt.Errorf("failed to send shutdown signal: %w", err)
+			// If signal sending fails, process is likely already gone
+			os.Remove(pidFile)
+			logger.Println("Process not running, removed PID file")
+			return nil
 		}
 
 		// Clean up PID file

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"syscall"
+
+	"github.com/pabotesu/kurohabaki-client/internal/logger"
+	"github.com/spf13/cobra"
+)
+
+var downCmd = &cobra.Command{
+	Use:   "down",
+	Short: "Stop the running WireGuard interface and agent",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Check if PID file exists
+		pidFile := "/var/run/kh-client.pid"
+		pidData, err := os.ReadFile(pidFile)
+		if err != nil {
+			return fmt.Errorf("no running agent found: %w", err)
+		}
+
+		// Parse PID
+		pid, err := strconv.Atoi(string(pidData))
+		if err != nil {
+			return fmt.Errorf("invalid PID in pidfile: %w", err)
+		}
+
+		// Find the process
+		process, err := os.FindProcess(pid)
+		if err != nil {
+			return fmt.Errorf("failed to find process with PID %d: %w", pid, err)
+		}
+
+		// Send SIGTERM to gracefully shut down the agent
+		logger.Println("Sending shutdown signal to agent (PID: " + strconv.Itoa(pid) + ")...")
+		if err := process.Signal(syscall.SIGTERM); err != nil {
+			return fmt.Errorf("failed to send shutdown signal: %w", err)
+		}
+
+		// Clean up PID file
+		if err := os.Remove(pidFile); err != nil {
+			logger.Printf("Warning: failed to remove PID file: %v", err)
+		}
+
+		logger.Println("Agent stopped successfully")
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(downCmd)
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -23,6 +23,7 @@ func New(wgIf *wg.WireGuardInterface, etcdClient *clientv3.Client, selfPubKey st
 	}
 }
 
+// Run should block until context is cancelled
 func (a *Agent) Run(ctx context.Context) {
 	// Log agent startup (debug mode only)
 	logger.Println("🟢 Agent.Run started")
@@ -37,7 +38,7 @@ func (a *Agent) Run(ctx context.Context) {
 	logger.Println("🟢 Launching StartPeerWatcher goroutine")
 	go StartPeerWatcher(ctx, a.etcdClient, a.wgIf, a.selfPubKey)
 
-	// Block until cancelled
+	// Block until context is done - THIS IS CRUCIAL
 	<-ctx.Done()
 
 	// Always log shutdown as it's important operational info

--- a/internal/util/paths.go
+++ b/internal/util/paths.go
@@ -1,0 +1,34 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// GetPidFilePath returns the appropriate path for the PID file
+// based on the current OS and user permissions
+func GetPidFilePath() string {
+	// For Windows
+	if runtime.GOOS == "windows" {
+		// Use %TEMP% directory on Windows
+		return filepath.Join(os.TempDir(), "kh-client.pid")
+	}
+
+	// For Unix-like systems (Linux, macOS)
+	// Check if we're running as root
+	if os.Geteuid() == 0 {
+		// Standard location for system daemons
+		return "/var/run/kh-client.pid"
+	}
+
+	// For non-root users on Unix systems
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		// Fallback to temporary directory if home directory is unavailable
+		return filepath.Join(os.TempDir(), "kh-client.pid")
+	}
+
+	// Use hidden file in user's home directory
+	return filepath.Join(homeDir, ".kh-client.pid")
+}


### PR DESCRIPTION
### 概要

- sudo ./kh-client-linux downとして実行します
- sudo ./kh-client-linux upされていないと、そもそもdownさせるものもないのでエラーとなります(agentの起動とかで検知できますかね)
- 現在のupコマンドはctrl+cでsigkillしていますが、完全にバックグランドで動作させ、downコマンドで停止します。
- しかし、up  --debugである場合は今まで通りctrl+cなどのsigkillでgraceful停止します。
